### PR TITLE
修复 Android 6 导入配置问题

### DIFF
--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -186,7 +186,12 @@ class SettingsFragment : PreferenceFragmentCompat(), TitleFragment {
     private fun importSettings() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
-            type = "application/json"
+            type = "*/*"
+            putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(
+                "application/json",
+                "text/plain",
+                "application/octet-stream"
+            ))
         }
         startActivityForResult(intent, PICK_SETTINGS_JSON_REQUEST)
     }


### PR DESCRIPTION
测试设备：华为M3
系统：EMUI 4.1.3
android 版本：6

老平板没有应用分身功能，同一个 PS5 机器的外服国服账号切换依赖配置导入功能，但现有的导入功能在测试设备上无法正常导入（[ISSUE](https://github.com/Axixi2233/chiaki-android/issues/5)），经排查可以简单修改导入配置修正

修正前：
<img width="415" height="206" alt="image" src="https://github.com/user-attachments/assets/a60b3712-36ac-4c66-9ec0-ce3cf7eda165" />

修正后：
<img width="414" height="180" alt="image" src="https://github.com/user-attachments/assets/489b627b-b33e-401a-a30a-cbd74ab87e0c" />

![img_v3_02s3_57102966-561f-458f-86d6-e7e1b131533g](https://github.com/user-attachments/assets/538395b0-983a-477e-8d2c-afe927ccc28d)